### PR TITLE
remove trailing tab from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.3	
+  - 0.3
   - 0.4
   - nightly
 notifications:


### PR DESCRIPTION
YAML.jl doesn't like this (probably a bug there)